### PR TITLE
Flux KDA Docker Image Multi Platform Support

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,23 @@
+name: Build_Flux_KDA_Node
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: install buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: build the image
+        run: |
+          docker buildx build --push \
+            --tag zelcash/kadena-chainweb-node:2.6 \
+            --platform linux/amd64,linux/arm64 .


### PR DESCRIPTION
With this change we build the docker image with github actions and upload it to docker hub.
It will have both support for linux/amd64 and linux/arm64